### PR TITLE
Add portable worktree functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ All tools share consistent vim-style patterns. See full details in each section 
 
 ### VCS/Git
 
-| Action | [Neovim](#git-fugitive) | [IntelliJ](#vcsgit) | [VS Code](#vs-code) |
-|---|---|---|---|
-| VCS panel | `Alt-v` / `Space vs` | `Alt-v` / `Space vs` | `Alt-v` / `Space vs` |
-| Show hunk diff | `Space vd` | `Space vd` | `Space vd` |
+| Action | [Tmux](#ai-agent-management-tmux-pilot) | [Neovim](#git-fugitive) | [IntelliJ](#vcsgit) | [VS Code](#vs-code) |
+|---|---|---|---|---|
+| VCS panel | `C-s d` | `Alt-v` / `Space vs` | `Alt-v` / `Space vs` | `Alt-v` / `Space vs` |
+| Show hunk diff | - | `Space vd` | `Space vd` | `Space vd` |
 
 ### AI Completion
 
@@ -140,6 +140,27 @@ Config: [tmux/tmux.conf](./tmux/tmux.conf)
 | `y` | Copy to system clipboard (in copy mode) |
 | `C-s p` | Paste from system clipboard |
 
+### AI Agent Management ([tmux-pilot](https://github.com/AlexBurdu/tmux-pilot))
+| Shortcut | Action |
+|---|---|
+| `C-s a` | Launch new agent (prompt, pick agent, name session) |
+| `C-s g` | Agent deck (fzf popup — all panes, live preview, actions) |
+| `C-s d` | VCS status popup (fugitive for git, lawrencium for hg) |
+
+#### Inside the agent deck (`C-s g`)
+| Shortcut | Action |
+|---|---|
+| `Enter` | Attach to selected pane |
+| `C-e` / `C-y` | Scroll preview (line) |
+| `C-d` / `C-u` | Scroll preview (half-page) |
+| `M-d` | Git diff popup |
+| `M-s` | Commit + push worktree |
+| `M-x` | Kill pane + cleanup worktree |
+| `M-p` | Pause agent (sends `/exit`) |
+| `M-r` | Resume agent (sends `claude --continue`) |
+| `M-n` | Launch new agent |
+| `Esc` | Close deck |
+
 ### Misc
 | Shortcut | Action |
 |---|---|
@@ -198,20 +219,22 @@ Edit filenames and `:w` to rename/move/delete files. Deletes go to trash.
 | `C-w H/J/K/L` | Move split directionally (nvim default) |
 
 ### Telescope (Fuzzy Finder)
-| Shortcut | Action |
-|---|---|
-| `Space ff` | Find files |
-| `Space fp` | Live grep (find in path) |
-| `Space fr` | Replace in path (Spectre) |
-| `Space fs` | Find symbol (LSP workspace symbols) |
-| `Space fc` | Find class/type (LSP type definitions) |
-| `Space fw` | Find workspace (zoxide), set cwd, open oil |
-| `Space e` | Recent files (current directory) |
-| `Space t` | LSP document symbols |
-| `C-t` | Pick from breadcrumb (dropbar.nvim) |
-| `gd` | Go to definition |
-| `Space fu` | Find references (LSP) |
-| `Space fi` | Find implementations (LSP) |
+| Shortcut | With LSP | Fallback (no LSP) |
+|---|---|---|
+| `Space ff` | Find files | Find files |
+| `Space fp` | Live grep (find in path) | Live grep |
+| `Space fr` | Replace in path (Spectre) | Replace in path |
+| `Space fs` | LSP workspace symbols | Live grep |
+| `Space fc` | LSP type definitions | Grep word under cursor |
+| `Space fw` | Find workspace (zoxide), set cwd, open oil | — |
+| `Space e` | Recent files (current directory) | — |
+| `Space t` | LSP document symbols | Fuzzy find in buffer |
+| `C-t` | Pick from breadcrumb (dropbar.nvim) | — |
+| `gd` | Go to definition | Grep word under cursor |
+| `Space fu` | Find references (LSP) | Grep word under cursor |
+| `Space fi` | Find implementations (LSP) | Grep word under cursor |
+
+LSP bindings automatically fall back to grep-based search when no language server is attached.
 
 ### Editing
 | Shortcut | Action |

--- a/aerospace/setup.sh
+++ b/aerospace/setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+# Symlinks AeroSpace tiling window manager config into ~/.config/aerospace.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== AeroSpace — tiling window manager config → ~/.config/aerospace ==="
 
-rm -rf ~/.config/aerospace.aerospace.toml
-mkdir -p ~/.config/aerospace
-ln -s $(pwd)/aerospace.toml ~/.config/aerospace/aerospace.toml
+link "$(pwd)/aerospace.toml" ~/.config/aerospace/aerospace.toml \
+  "AeroSpace tiling window manager configuration"

--- a/bash/json_merge.sh
+++ b/bash/json_merge.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Prompt-and-merge helper for JSON config files.
+# Requires jq. Source this from any setup.sh:
+#   source "$(dirname "$0")/../bash/json_merge.sh"
+
+# Deep-merge a source JSON file into a destination JSON file.
+# Shows a diff of what will change before prompting. Validates
+# both files as valid JSON before merging. Uses jq recursive
+# merge (source keys override target at all nesting levels,
+# but unrelated keys in target are preserved).
+# If the destination doesn't exist, copies the source instead.
+# Globals:
+#   None
+# Arguments:
+#   $1 - source JSON file (from dotfiles repo)
+#   $2 - destination JSON file (installed config location)
+#   $3 - human-readable description shown before the prompt
+# Outputs:
+#   Writes description, file paths, and a preview diff to
+#   stdout. Prompts for confirmation on stdin.
+# Returns:
+#   0 on success or if user declines.
+#   1 if source file is missing or either file is invalid JSON.
+merge_json() {
+  local src="$1" dst="$2" desc="$3"
+  printf '%s\n  merge %s into %s\n' "$desc" "$src" "$dst"
+
+  if [[ ! -f "$src" ]]; then
+    echo "  Error: source file not found: $src"
+    return 1
+  fi
+
+  # Validate source JSON
+  if ! jq empty "$src" 2>/dev/null; then
+    echo "  Error: invalid JSON in source: $src"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$dst")"
+
+  if [[ ! -f "$dst" ]]; then
+    echo "  Destination does not exist — will copy source."
+    read -rp "Copy? (y/n) " ans
+    if [[ "$ans" == "y" ]]; then
+      cp "$src" "$dst"
+    fi
+    return 0
+  fi
+
+  # Validate destination JSON
+  if ! jq empty "$dst" 2>/dev/null; then
+    echo "  Error: invalid JSON in destination: $dst"
+    return 1
+  fi
+
+  # Preview: show what will change
+  local merged
+  merged=$(jq -s '.[0] * .[1]' "$dst" "$src") || {
+    echo "  Error: merge failed"
+    return 1
+  }
+
+  echo ""
+  echo "  Changes:"
+  diff --color=auto \
+    <(jq --sort-keys . "$dst") \
+    <(echo "$merged" | jq --sort-keys .) \
+    | sed 's/^/    /' || true
+  echo ""
+
+  read -rp "Merge? (y/n) " ans
+  if [[ "$ans" == "y" ]]; then
+    echo "$merged" | jq . > "$dst.tmp" && mv "$dst.tmp" "$dst"
+  fi
+}

--- a/bash/link.sh
+++ b/bash/link.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Prompt-and-symlink helper for dotfiles setup scripts.
+# Source this from any setup.sh:
+#   source "$(dirname "$0")/../bash/link.sh"
+
+# Show a description and prompt before creating a symlink.
+# Creates parent directories as needed. Removes existing
+# file/symlink at the destination before linking.
+# Globals:
+#   None
+# Arguments:
+#   $1 - source path (file or directory in the dotfiles repo)
+#   $2 - destination path (where the symlink will be created)
+#   $3 - human-readable description shown before the prompt
+# Outputs:
+#   Writes description and path mapping to stdout,
+#   prompts for confirmation on stdin.
+# Returns:
+#   0 on success or if user declines.
+link() {
+  local src="$1" dst="$2" desc="$3"
+  printf '%s\n  %s → %s\n' "$desc" "$src" "$dst"
+  read -rp "Symlink? (y/n) " ans
+  if [[ "$ans" == "y" ]]; then
+    mkdir -p "$(dirname "$dst")"
+    rm -rf "$dst"
+    ln -s "$src" "$dst"
+  fi
+}

--- a/ghostty/setup.sh
+++ b/ghostty/setup.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
+# Symlinks Ghostty terminal config and themes into ~/.config/ghostty.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Ghostty — terminal config and themes → ~/.config/ghostty ==="
 
-CONFIG_DIR=~/.config/ghostty
+link "$(pwd)/config" ~/.config/ghostty/config \
+  "Ghostty terminal appearance and behavior settings"
 
-mkdir -p "$CONFIG_DIR"
-
-rm -rf "$CONFIG_DIR/config"
-ln -s "$(pwd)/config" "$CONFIG_DIR/config"
-
-rm -rf "$CONFIG_DIR/themes"
-ln -s "$(pwd)/themes" "$CONFIG_DIR/themes"
-
-echo "Ghostty configuration installed."
+link "$(pwd)/themes" ~/.config/ghostty/themes \
+  "Ghostty color themes (light/dark)"

--- a/karabiner/setup.sh
+++ b/karabiner/setup.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Symlinks Karabiner-Elements keyboard remapping config into ~/.config/karabiner.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Karabiner-Elements — keyboard remapping → ~/.config/karabiner ==="
 
-rm -rf ~/.config/karabiner/karabiner.json
-ln -s $(pwd)/karabiner.json ~/.config/karabiner/karabiner.json
+link "$(pwd)/karabiner.json" ~/.config/karabiner/karabiner.json \
+  "Karabiner-Elements keyboard remapping rules"

--- a/mc/ini
+++ b/mc/ini
@@ -82,7 +82,7 @@ editor_backup_extension=~
 editor_filesize_threshold=64M
 editor_stop_format_chars=-+*\\,.;:&>
 mcview_eof=
-skin=nicedark
+skin=seasons-winter16M
 
 filepos_max_saved_entries=1024
 
@@ -91,8 +91,8 @@ shell_directory_timeout=900
 
 [Layout]
 output_lines=0
-left_panel_size=47
-top_panel_size=14
+left_panel_size=95
+top_panel_size=39
 message_visible=true
 keybar_visible=true
 xterm_title=true
@@ -129,7 +129,7 @@ show_mini_info=true
 kilobyte_si=true
 mix_all_files=false
 show_backups=true
-show_dot_files=true
+show_dot_files=false
 fast_reload=false
 fast_reload_msg_shown=false
 mark_moves_down=true

--- a/mc/setup.sh
+++ b/mc/setup.sh
@@ -1,58 +1,54 @@
 #!/usr/bin/env bash
+# Symlinks Midnight Commander config directory into ~/.config/mc
+# and updates file handler paths in mc.ext.ini.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Midnight Commander — file manager config → ~/.config/mc ==="
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MC_CONFIG=~/.config/mc
 
-# Backup existing mc config
-rm -rf "$MC_CONFIG.bak"
-[ -e "$MC_CONFIG" ] && mv "$MC_CONFIG" "$MC_CONFIG.bak"
+link "$SCRIPT_DIR" "$MC_CONFIG" \
+  "Midnight Commander config directory (panels, keybindings, file handlers)"
 
-# Create a symlink to the mc config
-ln -s "$SCRIPT_DIR" "$MC_CONFIG"
-
-# Update mc.ext.ini to use open-file.sh for all handlers defined in handlers.ini
+# Update mc.ext.ini to use open-file.sh for all handlers
 update_handlers() {
-    local handlers_ini="$SCRIPT_DIR/handlers.ini"
-    local ext_ini="$SCRIPT_DIR/mc.ext.ini"
+  local handlers_ini="$SCRIPT_DIR/handlers.ini"
+  local ext_ini="$SCRIPT_DIR/mc.ext.ini"
 
-    [ ! -f "$handlers_ini" ] && return
-    [ ! -f "$ext_ini" ] && return
+  [ ! -f "$handlers_ini" ] && return
+  [ ! -f "$ext_ini" ] && return
 
-    # Extract handler types from handlers.ini (section names, excluding 'default')
-    local types=$(grep '^\[' "$handlers_ini" | tr -d '[]' | grep -v '^default$')
+  # Extract handler types from handlers.ini (section names, excluding 'default')
+  local types
+  types=$(grep '^\[' "$handlers_ini" | tr -d '[]' | grep -v '^default$')
 
-    for type in $types; do
-        # Try [Include/TYPE] section first (e.g., [Include/image])
-        if grep -q "^\[Include/$type\]" "$ext_ini"; then
-            sed -i'' -e "/^\[Include\/$type\]/,/^\[/{
-                s|^Open=.*|Open=$MC_CONFIG/open-file.sh $type %f|
-                s|^View=.*|View=$MC_CONFIG/open-file.sh $type %f|
-            }" "$ext_ini"
-            echo "Updated handler: [Include/$type]"
-        # Try direct [TYPE] section (e.g., [pdf])
-        elif grep -q "^\[$type\]" "$ext_ini"; then
-            sed -i'' -e "/^\[$type\]/,/^\[/{
-                s|^Open=.*|Open=$MC_CONFIG/open-file.sh $type %f|
-                s|^View=.*|View=$MC_CONFIG/open-file.sh $type %f|
-            }" "$ext_ini"
-            echo "Updated handler: [$type]"
-        else
-            echo "Warning: No section found for handler '$type'"
-        fi
-    done
-
-    # Update [Default] section for fallback handling
-    if grep -q "^\[Default\]" "$ext_ini"; then
-        sed -i'' -e "/^\[Default\]/,/^\[/{
-            s|^Open=.*|Open=$MC_CONFIG/open-file.sh default %f|
-        }" "$ext_ini"
-        echo "Updated handler: [Default]"
+  for type in $types; do
+    # Try [Include/TYPE] section first (e.g., [Include/image])
+    if grep -q "^\[Include/$type\]" "$ext_ini"; then
+      sed -i'' -e "/^\[Include\/$type\]/,/^\[/{
+        s|^Open=.*|Open=$MC_CONFIG/open-file.sh $type %f|
+        s|^View=.*|View=$MC_CONFIG/open-file.sh $type %f|
+      }" "$ext_ini"
+    # Try direct [TYPE] section (e.g., [pdf])
+    elif grep -q "^\[$type\]" "$ext_ini"; then
+      sed -i'' -e "/^\[$type\]/,/^\[/{
+        s|^Open=.*|Open=$MC_CONFIG/open-file.sh $type %f|
+        s|^View=.*|View=$MC_CONFIG/open-file.sh $type %f|
+      }" "$ext_ini"
     fi
+  done
 
-    # Clean up sed backup file on macOS
-    rm -f "$ext_ini-e"
+  # Update [Default] section for fallback handling
+  if grep -q "^\[Default\]" "$ext_ini"; then
+    sed -i'' -e "/^\[Default\]/,/^\[/{
+      s|^Open=.*|Open=$MC_CONFIG/open-file.sh default %f|
+    }" "$ext_ini"
+  fi
+
+  # Clean up sed backup file on macOS
+  rm -f "$ext_ini-e"
 }
 
 update_handlers
-
-echo "Midnight Commander config linked to $SCRIPT_DIR"
+echo "Midnight Commander setup complete."

--- a/setup.sh
+++ b/setup.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
-# Script that iterates through all directories looking for a setup.sh file to run from those directories.
+# Master setup — runs setup.sh in each subdirectory.
+# Prompts before each one so you can skip what you don't need.
+set -euo pipefail
 
 root_dir=$(pwd)
 
-# Find all setup.sh files in other directories than the current one.
-setup_files=$(find . -name "setup.sh" -not -path "./setup.sh")
-
-for setup in $setup_files; do
-  echo "Running setup.sh in $(dirname $setup)"
-  cd "$(dirname $setup)"
-  bash setup.sh
-  cd $root_dir
+# Find all setup.sh files in subdirectories
+for setup in */setup.sh; do
+  dir=$(dirname "$setup")
+  echo ""
+  read -rp "Run $dir/setup.sh? (y/n) " ans
+  if [[ "$ans" == "y" ]]; then
+    cd "$dir"
+    bash setup.sh
+    cd "$root_dir"
+  fi
 done
 
-echo "All setup.sh files have been run."
+echo ""
+echo "All selected setup scripts have been run."

--- a/terminator/setup.sh
+++ b/terminator/setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+# Symlinks Terminator terminal emulator config into ~/.config/terminator.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Terminator — terminal emulator config → ~/.config/terminator ==="
 
-rm -rf ~/.config/terminator/config
-ln -s $(pwd)/config ~/.config/terminator/config
-
+link "$(pwd)/config" ~/.config/terminator/config \
+  "Terminator terminal emulator configuration"

--- a/tridactyl/setup.sh
+++ b/tridactyl/setup.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
+# Symlinks Tridactyl (Firefox vim-mode) config into ~/.config/tridactyl.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Tridactyl — Firefox vim-mode keybindings → ~/.config/tridactyl ==="
 
-CONFIG_DIR=~/.config/tridactyl
-
-# Recursively create directories if they don't exist
-mkdir -p "$CONFIG_DIR"
-
-rm -rf $CONFIG_DIR/tridactylrc
-ln -s $(pwd)/tridactylrc $CONFIG_DIR/tridactylrc
+link "$(pwd)/tridactylrc" ~/.config/tridactyl/tridactylrc \
+  "Tridactyl vim-mode keybindings for Firefox"

--- a/vscode/setup.sh
+++ b/vscode/setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Symlinks VS Code keybindings and settings into the platform-specific config dir.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== VS Code — keybindings and settings → platform config dir ==="
 
 # Locations are different for Linux vs MacOS
 CONFIG_DIR=~/.config/Code/User
@@ -7,12 +10,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   CONFIG_DIR=~/Library/Application\ Support/Code/User
 fi
 
-# Recursively create directories if they don't exist
-mkdir -p "$CONFIG_DIR"
+link "$(pwd)/keybindings.json" "${CONFIG_DIR}/keybindings.json" \
+  "VS Code keyboard shortcuts (vim-consistent bindings)"
 
-rm -rf "${CONFIG_DIR}/keybindings.json"
-rm -rf "${CONFIG_DIR}/settings.json"
-
-ln -s "$SCRIPT_DIR/keybindings.json" "${CONFIG_DIR}/keybindings.json"
-ln -s "$SCRIPT_DIR/settings.json" "${CONFIG_DIR}/settings.json"
-
+link "$(pwd)/settings.json" "${CONFIG_DIR}/settings.json" \
+  "VS Code editor settings and preferences"

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Installs zsh plugins, symlinks zshrc into ~/.zshrc, and
+# worktree functions into ~/.config/zsh.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Zsh — plugins, zshrc → ~/.zshrc, worktree functions → ~/.config/zsh ==="
 
 # Install zoxide (smarter cd that tracks frequently used directories)
 echo ""
@@ -6,8 +11,7 @@ echo "zoxide is a smarter 'cd' command that learns your habits."
 echo "It lets you jump to frequently used directories with 'z <partial-name>'."
 echo "Example: 'z dot' could jump to ~/dotfiles"
 echo ""
-echo "Install zoxide? (y/n)"
-read -r response
+read -rp "Install zoxide? (y/n) " response
 if [ "$response" = "y" ]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     brew install zoxide
@@ -23,18 +27,20 @@ if [ "$response" = "y" ]; then
 fi
 
 # Clone themes & plugins
-git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
-git clone --depth=1 https://github.com/marlonrichert/zsh-autocomplete.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autocomplete
-git clone https://github.com/zsh-users/zsh-completions ${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-completions
-git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-autosuggestions
-git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-~/.fzf/install
-
-rm -rf ~/.zshrc
-echo "Do you want to copy or symlink ~/.zshrc? (c/s)"
-read -r response
-if [ "$response" = "c" ]; then
-  cp $(pwd)/zshrc ~/.zshrc
-elif [ "$response" = "s" ]; then
-  ln -s $(pwd)/zshrc ~/.zshrc
+echo ""
+read -rp "Install/update zsh plugins (powerlevel10k, autocomplete, completions, autosuggestions, fzf)? (y/n) " response
+if [ "$response" = "y" ]; then
+  git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k 2>/dev/null || true
+  git clone --depth=1 https://github.com/marlonrichert/zsh-autocomplete.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autocomplete 2>/dev/null || true
+  git clone https://github.com/zsh-users/zsh-completions ${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-completions 2>/dev/null || true
+  git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-autosuggestions 2>/dev/null || true
+  git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf 2>/dev/null || true
+  ~/.fzf/install
 fi
+
+echo ""
+link "$(pwd)/zshrc" ~/.zshrc \
+  "Zsh config (oh-my-zsh, powerlevel10k, vim-mode, fzf, aliases)"
+
+link "$(pwd)/worktree.zsh" ~/.config/zsh/worktree.zsh \
+  "Git worktree + agent launcher functions (wt-create, wt-launch, wt-list, wt-cleanup)"

--- a/zsh/worktree.zsh
+++ b/zsh/worktree.zsh
@@ -1,0 +1,216 @@
+#!/usr/bin/env zsh
+# Portable git worktree + agent launcher functions.
+# Works with any git repo — auto-detects repo root and remote.
+#
+# Usage:
+#   wt-create <issue-number>   Create worktree + claim issue
+#   wt-launch <issue-number> [agent]  Create + tmux window + agent
+#   wt-list                    List worktrees for current repo
+#   wt-cleanup <issue-number>  Remove worktree + prune
+
+# Enable experimental Claude Code agent teams
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+
+# Get the basename of the current git repository.
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   Writes repo name to stdout (e.g. "alexlibraria").
+# Returns:
+#   1 if not inside a git repository.
+_wt_repo_name() {
+  basename "$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+}
+
+# Get the absolute path to the current git repository root.
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   Writes absolute path to stdout.
+# Returns:
+#   1 if not inside a git repository.
+_wt_repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || return 1
+}
+
+# Get the GitHub owner/repo identifier for the current repo.
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   Writes "owner/repo" to stdout (e.g. "AlexBurdu/alexlibraria").
+# Returns:
+#   1 if gh CLI is unavailable or repo has no GitHub remote.
+_wt_gh_repo() {
+  gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || return 1
+}
+
+# Build the worktree path for a given issue number.
+# Convention: ~/<repo-name>-worktree/issue-<N>
+# Globals:
+#   HOME
+# Arguments:
+#   $1 - issue number
+# Outputs:
+#   Writes the worktree path to stdout.
+# Returns:
+#   1 if repo name cannot be determined.
+_wt_path() {
+  local repo_name issue_num
+  repo_name=$(_wt_repo_name) || return 1
+  issue_num="$1"
+  echo "$HOME/${repo_name}-worktree/issue-${issue_num}"
+}
+
+# Create a git worktree for an issue and claim it on GitHub.
+# Creates branch issue-<N> from main, assigns the issue to
+# yourself, and posts a "Starting work" comment.
+# Globals:
+#   HOME
+# Arguments:
+#   $1 - GitHub issue number
+# Outputs:
+#   Progress messages to stdout.
+# Returns:
+#   1 if not in a git repo, worktree already exists,
+#   or git worktree add fails.
+wt-create() {
+  if [[ -z "$1" ]]; then
+    echo "Usage: wt-create <issue-number>"
+    return 1
+  fi
+
+  local issue_num="$1"
+  local repo_root wt_path gh_repo
+
+  repo_root=$(_wt_repo_root) || {
+    echo "Error: not inside a git repository"; return 1
+  }
+  wt_path=$(_wt_path "$issue_num") || return 1
+  gh_repo=$(_wt_gh_repo)
+
+  if [[ -d "$wt_path" ]]; then
+    echo "Worktree already exists: $wt_path"
+    return 1
+  fi
+
+  # Create worktree with dedicated branch
+  git -C "$repo_root" worktree add \
+    -b "issue-${issue_num}" "$wt_path" main || return 1
+
+  # Claim issue on GitHub if gh is available and repo detected
+  if [[ -n "$gh_repo" ]]; then
+    gh issue edit "$issue_num" --add-assignee "@me" \
+      --repo "$gh_repo" 2>/dev/null || true
+    gh issue comment "$issue_num" \
+      --body "Starting work on this" \
+      --repo "$gh_repo" 2>/dev/null || true
+  fi
+
+  echo "Created worktree: $wt_path (branch: issue-${issue_num})"
+}
+
+# Create a worktree (if needed) and launch an AI agent in a
+# new tmux window. Defaults to Claude Code if no agent is
+# specified.
+# Globals:
+#   HOME, TMUX
+# Arguments:
+#   $1 - GitHub issue number
+#   $2 - agent name: "claude" (default) or "gemini"
+# Outputs:
+#   Opens a new tmux window named issue-<N>, or prints
+#   instructions if not inside tmux.
+# Returns:
+#   1 if issue number is missing, agent is unknown, or
+#   worktree creation fails.
+wt-launch() {
+  if [[ -z "$1" ]]; then
+    echo "Usage: wt-launch <issue-number> [claude|gemini]"
+    return 1
+  fi
+
+  local issue_num="$1"
+  local agent="${2:-claude}"
+  local wt_path
+
+  wt_path=$(_wt_path "$issue_num") || return 1
+
+  # Create worktree if it doesn't exist
+  if [[ ! -d "$wt_path" ]]; then
+    wt-create "$issue_num" || return 1
+  fi
+
+  # Determine agent command
+  local agent_cmd
+  case "$agent" in
+    claude)  agent_cmd="claude" ;;
+    gemini)  agent_cmd="gemini" ;;
+    *)       echo "Unknown agent: $agent"; return 1 ;;
+  esac
+
+  # Launch in new tmux window
+  if [[ -n "$TMUX" ]]; then
+    tmux new-window -n "issue-${issue_num}" \
+      "cd '$wt_path' && $agent_cmd"
+  else
+    echo "Not in tmux. cd into $wt_path and run $agent_cmd"
+  fi
+}
+
+# List all git worktrees for the current repository.
+# Globals:
+#   None
+# Arguments:
+#   None
+# Outputs:
+#   Writes git worktree list output to stdout.
+# Returns:
+#   1 if not inside a git repository.
+wt-list() {
+  local repo_root
+  repo_root=$(_wt_repo_root) || {
+    echo "Error: not inside a git repository"; return 1
+  }
+  git -C "$repo_root" worktree list
+}
+
+# Remove a worktree for a given issue and prune stale entries.
+# Globals:
+#   HOME
+# Arguments:
+#   $1 - GitHub issue number
+# Outputs:
+#   Confirmation message to stdout.
+# Returns:
+#   1 if not in a git repo, worktree doesn't exist, or
+#   git worktree remove fails.
+wt-cleanup() {
+  if [[ -z "$1" ]]; then
+    echo "Usage: wt-cleanup <issue-number>"
+    return 1
+  fi
+
+  local issue_num="$1"
+  local repo_root wt_path
+
+  repo_root=$(_wt_repo_root) || {
+    echo "Error: not inside a git repository"; return 1
+  }
+  wt_path=$(_wt_path "$issue_num") || return 1
+
+  if [[ ! -d "$wt_path" ]]; then
+    echo "Worktree not found: $wt_path"
+    return 1
+  fi
+
+  git -C "$repo_root" worktree remove "$wt_path" || return 1
+  git -C "$repo_root" worktree prune
+
+  echo "Removed worktree: $wt_path"
+}

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -125,3 +125,6 @@ fi
 # zoxide - smarter cd command (tracks frequently used directories)
 eval "$(zoxide init zsh)"
 
+# Portable git worktree + agent launcher functions
+[[ -f "$HOME/.config/zsh/worktree.zsh" ]] && source "$HOME/.config/zsh/worktree.zsh"
+


### PR DESCRIPTION
## Summary
- New `zsh/worktree.zsh` with `wt-create`, `wt-launch`, `wt-list`, `wt-cleanup` functions
- Sourced from `zsh/zshrc`
- Auto-detects repo root and GitHub remote — works with any git repo
- `wt-launch` creates tmux window + starts agent (claude/gemini/aider)

## Test plan
- [ ] `wt-create 99` from a git repo — verify worktree created
- [ ] `wt-launch 99` — verify tmux window + agent launch
- [ ] `wt-list` — verify worktrees listed
- [ ] `wt-cleanup 99` — verify worktree removed