### PR TITLE
Move tmux status hook to shared location, add tmux-pilot

### DIFF
--- a/tmux/hooks/tmux-status-hook.sh
+++ b/tmux/hooks/tmux-status-hook.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Agent hook: updates the tmux window name to reflect agent
+# state (working / waiting / ready).
+#
+# Works with Claude Code, Gemini CLI, or any agent that calls
+# it with JSON on stdin.
+#
+# Usage: tmux-status-hook.sh <state>
+#   States: prompt, working, waiting, ready, resume
+#
+# Dependencies: tmux
+
+# Exit silently if not inside tmux.
+[ -z "$TMUX" ] && exit 0
+
+STATE="${1:-working}"
+PANE_ID=$(tmux display-message -p '#{pane_id}')
+STATE_FILE="/tmp/claude-tmux-${PANE_ID//[%]/_}"
+
+save_name() { printf '%s' "$1" > "$STATE_FILE"; }
+
+load_name() {
+  if [ -f "$STATE_FILE" ]; then
+    cat "$STATE_FILE"
+  else
+    echo "claude"
+  fi
+}
+
+# Get current window name (strip emoji prefix if present).
+current_name() {
+  tmux display-message -p '#{window_name}' | sed 's/^[✋⏳]*//'
+}
+
+# Check if name contains issue/PR reference (worth preserving).
+has_ref() {
+  printf '%s' "$1" | grep -qE '(issue|pr)-[0-9]+'
+}
+
+# Detect PR/issue references from raw hook JSON
+# on stdin (no JSON parser needed).
+detect_refs() {
+  local input pr_num issue_num
+  input=$(cat)
+
+  # GitHub URL patterns (most reliable).
+  pr_num=$(printf '%s' "$input" \
+    | grep -oE '/pull/[0-9]+' | head -1 \
+    | grep -oE '[0-9]+')
+  issue_num=$(printf '%s' "$input" \
+    | grep -oE '/issues/[0-9]+' | head -1 \
+    | grep -oE '[0-9]+')
+
+  # Keyword + #N fallbacks.
+  if [ -z "$pr_num" ]; then
+    pr_num=$(printf '%s' "$input" \
+      | grep -oiE '(review|pr) #[0-9]+' \
+      | head -1 | grep -oE '[0-9]+')
+  fi
+  if [ -z "$issue_num" ]; then
+    issue_num=$(printf '%s' "$input" \
+      | grep -oiE '(fix|issue|close) #[0-9]+' \
+      | head -1 | grep -oE '[0-9]+')
+  fi
+
+  # Build the name.
+  if [ -n "$pr_num" ] && [ -n "$issue_num" ]; then
+    echo "pr-${pr_num}-issue-${issue_num}"
+  elif [ -n "$pr_num" ]; then
+    echo "pr-${pr_num}"
+  elif [ -n "$issue_num" ]; then
+    echo "issue-${issue_num}"
+  fi
+}
+
+case "$STATE" in
+  prompt)
+    # Fired on UserPromptSubmit — parse the prompt for references.
+    # Only update name if NEW refs found; preserve existing issue/PR.
+    saved=$(load_name)
+    new_ref=$(detect_refs)
+
+    if [ -n "$new_ref" ]; then
+      # New ref found in prompt — use it.
+      name="$new_ref"
+    elif has_ref "$saved"; then
+      # No new ref, but we have a saved issue/PR — keep it.
+      name="$saved"
+    else
+      # No ref anywhere — keep whatever we have.
+      name="${saved:-claude}"
+    fi
+    save_name "$name"
+    tmux rename-window -t "$PANE_ID" "$name"
+    ;;
+  working)
+    # Fired on SessionStart — preserve existing issue/PR name,
+    # otherwise fall back to "claude".
+    saved=$(load_name)
+
+    if has_ref "$saved"; then
+      name="$saved"
+    else
+      name="${saved:-claude}"
+    fi
+    save_name "$name"
+    tmux rename-window -t "$PANE_ID" "$name"
+    ;;
+  waiting)
+    # Fired on Stop — prepend hand emoji.
+    # Preserve the saved name (don't overwrite).
+    name=$(load_name)
+    [ -z "$name" ] && name="claude"
+    tmux rename-window -t "$PANE_ID" "✋${name}"
+    ;;
+  resume)
+    # Fired on PreToolUse — agent is working, remove hand.
+    # Preserve the saved name (don't overwrite).
+    name=$(load_name)
+    [ -z "$name" ] && name="claude"
+    tmux rename-window -t "$PANE_ID" "$name"
+    ;;
+  ready)
+    # Fired on SessionEnd — clean up.
+    tmux rename-window -t "$PANE_ID" "ready"
+    rm -f "$STATE_FILE"
+    ;;
+esac
+
+exit 0

--- a/tmux/setup.sh
+++ b/tmux/setup.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Symlinks tmux config and shared hooks into ~/.tmux.conf and ~/.config/tmux.
+set -euo pipefail
+source "$(dirname "$0")/../bash/link.sh"
+echo "=== Tmux — config → ~/.tmux.conf, hooks → ~/.config/tmux ==="
 
-rm -rf ~/.tmux.conf
-ln -s $(pwd)/tmux.conf ~/.tmux.conf
+link "$(pwd)/tmux.conf" ~/.tmux.conf \
+  "Tmux configuration (keybindings, plugins, catppuccin theme)"
+
+link "$(pwd)/set-themes.sh" ~/.config/tmux/set-themes.sh \
+  "Theme switcher (syncs light/dark across apps based on OS appearance)"
+
+link "$(pwd)/hooks/tmux-status-hook.sh" ~/.config/tmux/hooks/tmux-status-hook.sh \
+  "Agent hooks (tmux window name updates on agent state changes)"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -105,6 +105,13 @@ set pane-active-border-style fg=blue
 # Set theme based on time of day (dark after 20:00, light otherwise)
 run-shell '~/.config/tmux/set-themes.sh'
 
+# AI agent management — launch, monitor, orchestrate agents
+set -g @plugin 'AlexBurdu/tmux-pilot'
+
+# Enhanced window chooser with pane info (prefix+w)
+bind w choose-tree -wF \
+  "#{window_index}: #{window_name}  #{pane_title}  #{pane_current_path}"
+
 # Initialize TMUX plugin manager (keep at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
## Summary
- Move `tmux-status-hook.sh` from `claude-code/hooks/` to `tmux/hooks/` — now agent-agnostic
- Add [tmux-pilot](https://github.com/AlexBurdu/tmux-pilot) TPM plugin for agent orchestration
- Enhanced `prefix+w` window chooser showing pane title and working directory

## Test plan
- [ ] Verify `~/.claude/hooks` symlink resolves to `tmux/hooks/`
- [ ] Verify tmux status updates when Claude Code starts/stops
- [ ] `prefix+w` shows enhanced format with pane info
- [ ] tmux-pilot installs via TPM (`prefix+I`)