### PR TITLE
Add vim-lawrencium plugin for Mercurial support

### DIFF
--- a/nvim/lua/plugins/fugitive.lua
+++ b/nvim/lua/plugins/fugitive.lua
@@ -2,6 +2,9 @@
 -- https://github.com/tpope/vim-fugitive
 return {
   "tpope/vim-fugitive",
+  cond = function()
+    return vim.fn.finddir(".git", vim.fn.getcwd() .. ";") ~= ""
+  end,
   config = function()
     vim.keymap.set("n", "<leader>vs", vim.cmd.Git)
     vim.keymap.set("n", "<M-v>", vim.cmd.Git)

--- a/nvim/lua/plugins/lawrencium.lua
+++ b/nvim/lua/plugins/lawrencium.lua
@@ -2,4 +2,11 @@
 -- https://github.com/ludovicchabant/vim-lawrencium
 return {
   "ludovicchabant/vim-lawrencium",
+  cond = function()
+    return vim.fn.finddir(".hg", vim.fn.getcwd() .. ";") ~= ""
+  end,
+  config = function()
+    vim.keymap.set("n", "<leader>vs", "<cmd>Hgstatus<CR>")
+    vim.keymap.set("n", "<M-v>", "<cmd>Hgstatus<CR>")
+  end,
 }

--- a/nvim/lua/plugins/lawrencium.lua
+++ b/nvim/lua/plugins/lawrencium.lua
@@ -1,0 +1,5 @@
+-- Mercurial (hg) integration for Neovim
+-- https://github.com/ludovicchabant/vim-lawrencium
+return {
+  "ludovicchabant/vim-lawrencium",
+}

--- a/nvim/setup.sh
+++ b/nvim/setup.sh
@@ -61,6 +61,7 @@ plugin_desc() {
     copilot.lua)          echo "copilot — GitHub Copilot AI code completion" ;;
     dropbar.lua)          echo "dropbar — breadcrumb navigation bar showing code context" ;;
     fugitive.lua)         echo "fugitive — Git integration (status, diff, blame)" ;;
+    lawrencium.lua)       echo "lawrencium — Mercurial (hg) integration (status, diff, log)" ;;
     lsp.lua)              echo "lsp — language server protocol with Mason and completion" ;;
     nightfox-theme.lua)   echo "nightfox — color theme with light/dark variants" ;;
     oil.lua)              echo "oil — file explorer (replaces netrw, supports trash)" ;;


### PR DESCRIPTION
## Summary

- Add [vim-lawrencium](https://github.com/ludovicchabant/vim-lawrencium) as a lazy.nvim plugin for Mercurial (hg) repo support
- Add `<leader>vs` and `<M-v>` bindings for `:Hgstatus` (matching fugitive)
- Conditional loading: fugitive only loads in git repos, lawrencium only in hg repos
- Add plugin description to `nvim/setup.sh`

Closes #1

## Test plan

- [ ] Open nvim in an hg repo and verify `:Hgstatus`, `:Hgdiff`, `:Hglog` work
- [ ] Verify `<leader>vs` and `<M-v>` open `:Hgstatus` in an hg repo
- [ ] Verify fugitive still loads normally in a git repo
- [ ] Verify lawrencium does not load in a git repo (and vice versa)