### PR TITLE
Modular Gemini CLI hooks + merge_json editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,14 @@ Config: [karabiner/karabiner.json](./karabiner/karabiner.json)
 
 ---
 
+## Gemini CLI
+
+Setup: [gemini/setup.sh](./gemini/setup.sh) | [Full docs](./gemini/README.md)
+
+Generates `~/.gemini/settings.json` from base settings + modular hook groups. Each hook group is prompted separately during setup, so you can pick which ones to install per machine.
+
+---
+
 ## Zoxide
 
 Config: [zsh/zshrc](./zsh/zshrc) (init line)

--- a/claude-code/CLAUDE.md
+++ b/claude-code/CLAUDE.md
@@ -10,3 +10,4 @@
 
 - Use GitHub PR labels for categorization (e.g. `bug`, `enhancement`, `refactor`)
 - Do NOT encode type in commit messages or PR titles
+- Do NOT add "Generated with Claude Code" lines to pull requests

--- a/gemini/GEMINI.md
+++ b/gemini/GEMINI.md
@@ -10,3 +10,4 @@
 
 - Use GitHub PR labels for categorization (e.g. `bug`, `enhancement`, `refactor`)
 - Do NOT encode type in commit messages or PR titles
+- Do NOT add "Generated with" watermark lines to pull requests

--- a/gemini/README.md
+++ b/gemini/README.md
@@ -1,0 +1,60 @@
+# Gemini CLI
+
+Config: [settings.json](./settings.json) | Instructions: [GEMINI.md](./GEMINI.md)
+
+## Setup
+
+```bash
+gemini/setup.sh
+```
+
+Generates `~/.gemini/settings.json` by merging base settings with selected hook groups, then symlinks instructions and prompts for command groups.
+
+## Structure
+
+```
+gemini/
+  settings.json          # Base settings (editor, theme, tools, privacy, etc.)
+  GEMINI.md              # Global instructions (commit format, conventions)
+  hooks/
+    tmux.json            # Tmux status indicator + workdir tracking
+    formatters.json      # Buildifier (.bzl) + ktfmt (.kt) auto-formatting
+  commands/
+    ...                  # Slash command groups (prompted during setup)
+```
+
+## Modular Hooks
+
+Hooks are split into separate files under `hooks/`. Each file is a JSON fragment:
+
+```json
+{
+  "_description": "Shown during setup prompt",
+  "hooks": {
+    "EventName": [...]
+  }
+}
+```
+
+During setup, each hook group is prompted independently. Selected hooks are merged into the base settings using array concatenation per event (so multiple groups can contribute to the same event like `AfterTool`). The final result is written to `~/.gemini/settings.json` via `merge_json`, which shows a diff and lets you accept, decline, or edit before writing.
+
+### Hook groups
+
+| File | Description | Requirements |
+|---|---|---|
+| `tmux.json` | Status bar indicator (working/waiting/ready) + `@pilot-workdir` tracking on file writes | tmux, [tmux-pilot](https://github.com/AlexBurdu/tmux-pilot) |
+| `formatters.json` | Auto-format `.bzl` and `.kt` files after Gemini writes them | `buildifier`, `ktfmt` |
+
+### Adding a new hook group
+
+Create a JSON file in `hooks/` following the fragment format above. It will be picked up automatically on the next `setup.sh` run.
+
+## merge_json
+
+The setup uses the shared `bash/json_merge.sh` helper for the final write. It:
+
+1. Shows a diff of what will change
+2. Prompts with `y/n/e` — accept, decline, or open in `$EDITOR`
+3. Validates JSON before writing (when editing)
+
+This means `~/.gemini/settings.json` is a **generated file**, not a symlink. Any local edits to it will show up as a diff on the next setup run.

--- a/gemini/hooks/formatters.json
+++ b/gemini/hooks/formatters.json
@@ -1,0 +1,25 @@
+{
+  "_description": "AfterTool formatters (buildifier for .bzl, ktfmt for .kt)",
+  "hooks": {
+    "AfterTool": [
+      {
+        "matcher": "write_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.bzl) buildifier \"$f\";; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "write_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.kt) ktfmt --kotlinlang-style \"$f\";; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gemini/hooks/tmux.json
+++ b/gemini/hooks/tmux.json
@@ -1,0 +1,64 @@
+{
+  "_description": "Tmux session lifecycle hooks (status indicator + workdir tracking)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "name": "tmux-status-working",
+            "type": "command",
+            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh working; printf '{\"decision\":\"allow\"}'"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "tmux-status-working",
+            "type": "command",
+            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh working; printf '{\"decision\":\"allow\"}'"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "tmux-status-waiting",
+            "type": "command",
+            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh waiting; printf '{\"decision\":\"allow\"}'"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "write_file|edit_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -I{} sh -c 'tmux set-option -p @pilot-workdir \"$(dirname \"{}\")\" 2>/dev/null; true'"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "exit",
+        "hooks": [
+          {
+            "name": "tmux-status-ready",
+            "type": "command",
+            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh ready; printf '{\"decision\":\"allow\"}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/gemini/settings.json
+++ b/gemini/settings.json
@@ -38,67 +38,6 @@
   },
   "ide": {
     "enabled": true
-  },
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "name": "tmux-status-working",
-            "type": "command",
-            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh working; printf '{\"decision\":\"allow\"}'"
-          }
-        ]
-      }
-    ],
-    "BeforeAgent": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "name": "tmux-status-working",
-            "type": "command",
-            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh working; printf '{\"decision\":\"allow\"}'"
-          }
-        ]
-      }
-    ],
-    "AfterAgent": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "name": "tmux-status-waiting",
-            "type": "command",
-            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh waiting; printf '{\"decision\":\"allow\"}'"
-          }
-        ]
-      }
-    ],
-    "AfterTool": [
-      {
-        "matcher": "write_file|edit_file",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | xargs -I{} sh -c 'tmux set-option -p @pilot-workdir \"$(dirname \"{}\")\" 2>/dev/null; true'"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "matcher": "exit",
-        "hooks": [
-          {
-            "name": "tmux-status-ready",
-            "type": "command",
-            "command": "$HOME/.config/tmux/hooks/tmux-status-hook.sh ready; printf '{\"decision\":\"allow\"}'"
-          }
-        ]
-      }
-    ]
   }
 }
 


### PR DESCRIPTION
## Summary
- Split Gemini hooks into separate files under `gemini/hooks/` (tmux status/workdir, formatters) so each group can be installed independently per machine
- Setup script now prompts for each hook group and merges selected ones into the generated `~/.gemini/settings.json`
- Add `e` (edit in `$EDITOR`) option to `merge_json` prompts with JSON validation before writing
- Add `gemini/README.md` documenting the modular hooks system

## Test plan
- [ ] Run `gemini/setup.sh` — verify each hook group is prompted separately
- [ ] Accept all → `jq empty ~/.gemini/settings.json` passes, all hooks present
- [ ] Accept only tmux → verify only tmux hooks appear, no formatters
- [ ] Choose `e` at merge prompt → editor opens, JSON validated on save